### PR TITLE
fix defining arch in Makefile for ko

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ REGISTRY?=gcr.io/k8s-minikube
 VERSION=v0.0.9
 GOOS?=$(shell go env GOOS)
 GOARCH?=$(shell go env GOARCH)
+ARCH=$(if $(findstring amd64, $(GOARCH)),x86_64,$(GOARCH))
 KO_VERSION=0.11.2
 
 build: ## Build the gcp-auth-webhook binary
@@ -10,7 +11,7 @@ build: ## Build the gcp-auth-webhook binary
 .PHONY: image
 image: ## Create and push multiarch manifest and images
 	@read -p "This will build and push $(REGISTRY)/gcp-auth-webhook:$(VERSION). Do you want to proceed? (Y/N): " confirm && echo $$confirm | grep -iq "^[yY]" || exit 1;
-	curl -L https://github.com/google/ko/releases/download/v$(KO_VERSION)/ko_$(KO_VERSION)_$(GOOS)_$(GOARCH).tar.gz | tar xzf - ko && chmod +x ./ko
+	curl -L https://github.com/google/ko/releases/download/v$(KO_VERSION)/ko_$(KO_VERSION)_$(GOOS)_$(ARCH).tar.gz | tar xzf - ko && chmod +x ./ko
 	KO_DOCKER_REPO=$(REGISTRY) ./ko publish -B . --platform all -t $(VERSION)
 	rm ./ko
 


### PR DESCRIPTION
ko uses x86_64 for amd64 in their binary names but follows the GOARCH convention for the rest of their binaries, so let's fix that on our end.