### PR TITLE
Add update check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ ARCH=$(if $(findstring amd64, $(GOARCH)),x86_64,$(GOARCH))
 KO_VERSION=0.11.2
 
 build: ## Build the gcp-auth-webhook binary
-	CGO_ENABLED=0 GOOS=linux go build -o out/gcp-auth-webhook server.go
+	CGO_ENABLED=0 GOOS=linux go build -ldflags="-X 'main.Version=$(VERSION)'" -o out/gcp-auth-webhook server.go
 
 .PHONY: image
 image: ## Create and push multiarch manifest and images

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/GoogleContainerTools/gcp-auth-webhook
 go 1.18
 
 require (
+	github.com/blang/semver/v4 v4.0.0
 	k8s.io/api v0.24.1
 	k8s.io/apimachinery v0.24.1
 )

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
+github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
+github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=


### PR DESCRIPTION
If the current version is older than the latest version available the server will output the following message on startup.

`gcp-auth-webhook v0.0.9 is available!`