### PR TITLE
Added an env var to use a mock token instead of fetching the real one

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ A server that includes:
 * A mutating webhook that will patch any newly created service accounts in your Kubernetes cluster with an image pull secret.
 * A thread that monitors namespaces to make sure all namespaces include a image pull secret to be able to pull from GCR and AR.
 
+Setting the environment variable `MOCK_GOOGLE_TOKEN` to `true` will prevent using the google application credentials to fetch the token used for the image pull secret. Instead the token will be mocked.
+
 ## Deployment
 Use the image `gcr.io/k8s-minikube/gcp-auth-webhook` as the image for a Deployment in your Kubernetes manifest and add that to a MutatingWebhookConfiguration. See [minikube](https://github.com/kubernetes/minikube/blob/master/deploy/addons/gcp-auth/gcp-auth-webhook.yaml.tmpl) for details.
 


### PR DESCRIPTION
This env variable can be used for integration tests. It will allow the image pull secrets to be added to namespaces with invalid credentials.