### PR TITLE
Changed the base image in the Dockerfile to be the same as ko

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM scratch
+# base image is the same as ko (see https://ko.build/configuration/)
+FROM gcr.io/distroless/static:nonroot
 COPY gcp-auth-webhook /gcp-auth-webhook
 ENTRYPOINT ["/gcp-auth-webhook"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,6 @@
 # limitations under the License.
 
 # base image is the same as ko (see https://ko.build/configuration/)
-FROM gcr.io/distroless/static:nonroot
+FROM cgr.dev/chainguard/static:latest
 COPY gcp-auth-webhook /gcp-auth-webhook
 ENTRYPOINT ["/gcp-auth-webhook"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# base image is the same as ko (see https://ko.build/configuration/)
+# base image is the same as ko's default
 FROM cgr.dev/chainguard/static:latest
 COPY gcp-auth-webhook /gcp-auth-webhook
 ENTRYPOINT ["/gcp-auth-webhook"]

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ A server that includes:
 * A mutating webhook that will patch any newly created service accounts in your Kubernetes cluster with an image pull secret.
 * A thread that monitors namespaces to make sure all namespaces include a image pull secret to be able to pull from GCR and AR.
 
+Setting the environment variable `MOCK_GOOGLE_TOKEN` to `true` will prevent using the google application credentials to fetch the token used for the image pull secret. Instead the token will be mocked.
+
 ## Deployment
 Use the image `gcr.io/k8s-minikube/gcp-auth-webhook` as the image for a Deployment in your Kubernetes manifest and add that to a MutatingWebhookConfiguration. See [minikube](https://github.com/kubernetes/minikube/blob/master/deploy/addons/gcp-auth/gcp-auth-webhook.yaml.tmpl) for details.
 

--- a/README.md
+++ b/README.md
@@ -12,11 +12,6 @@ Use the image `gcr.io/k8s-minikube/gcp-auth-webhook` as the image for a Deployme
 
 ## Running Locally
 The easiest way to run the server locally is:
-* Remove `FROM scratch` in the Dockerfile and replace it with the following to ensure https requests work properly locally:
-```
-FROM alpine
-RUN apk --no-cache add ca-certificates
-```
 * Modify [minikube's](https://github.com/kubernetes/minikube/blob/master/deploy/addons/gcp-auth/gcp-auth-webhook.yaml.tmpl) gcp-auth Deployment image to be `local/gcp-auth-webhook:$(VERSION)` (replace `$(VERSION)` with your version)
 * Build and run minikube
 * Run `eval $(path_to_minikube/minikube docker-env)` and then `make local-image` to make the image available from within minikube


### PR DESCRIPTION
This makes the local development image the same as the production one, avoiding the cert errors that appeared with scratch.

Ideally we should be able to just use ko locally and avoid the need for a Dockerfile altogether. I haven't had a chance to look into this yet but there are flags like `-L` to the `ko build` command that might work.