### PR TITLE
Use mock registry if `MOCK_GOOGLE_TOKEN` is true

### DIFF
--- a/server.go
+++ b/server.go
@@ -119,7 +119,12 @@ func createPullSecret(clientset *kubernetes.Clientset, ns *corev1.Namespace, cre
 	}
 
 	registries := append(gcr_config.DefaultGCRRegistries[:], gcr_config.DefaultARRegistries[:]...)
-	// The MOCK_GOOGLE_TOKEN env var prevents using credentials to fetch the token. Instead the token will be mocked.
+
+	// The MOCK_GOOGLE_TOKEN env var prevents using credentials to fetch the
+	// token. Instead the token will be mocked. It also sets a mock registry
+	// due to pulls to Artifact Registry for publicly available images with
+	// mock credentials causing unauthorized errors. See:
+	// https://github.com/kubernetes/minikube/issues/19714
 	mockToken, _ := strconv.ParseBool(os.Getenv("MOCK_GOOGLE_TOKEN"))
 	var token *oauth2.Token
 	if mockToken {

--- a/server.go
+++ b/server.go
@@ -118,11 +118,13 @@ func createPullSecret(clientset *kubernetes.Clientset, ns *corev1.Namespace, cre
 		}
 	}
 
+	registries := append(gcr_config.DefaultGCRRegistries[:], gcr_config.DefaultARRegistries[:]...)
 	// The MOCK_GOOGLE_TOKEN env var prevents using credentials to fetch the token. Instead the token will be mocked.
 	mockToken, _ := strconv.ParseBool(os.Getenv("MOCK_GOOGLE_TOKEN"))
 	var token *oauth2.Token
 	if mockToken {
 		token = &oauth2.Token{AccessToken: "mock_access_token"}
+		registries = []string{"mock-registry"}
 	} else {
 		token, err = creds.TokenSource.Token()
 		if err != nil {
@@ -130,7 +132,6 @@ func createPullSecret(clientset *kubernetes.Clientset, ns *corev1.Namespace, cre
 		}
 	}
 	var dockercfg string
-	registries := append(gcr_config.DefaultGCRRegistries[:], gcr_config.DefaultARRegistries[:]...)
 	for _, reg := range registries {
 		dockercfg += fmt.Sprintf(`"https://%s":{"username":"oauth2accesstoken","password":"%s","email":"none"},`, reg, token.AccessToken)
 	}


### PR DESCRIPTION
As outlined in https://github.com/kubernetes/minikube/issues/19714, after moving from GCR to AR, using mock credentials causes authentication issues even on publicly available images. So if `MOCK_GOOGLE_TOKEN` is true, set a mock registry to not prevent pulls from AR.