### PR TITLE
Request the correct OAuth scopes when using service account keys.

### DIFF
--- a/server.go
+++ b/server.go
@@ -79,7 +79,7 @@ func watchNamespaces() error {
 
 	// grab credentials from where GCP would normally look
 	ctx := context.Background()
-	creds, err := google.FindDefaultCredentials(ctx)
+	creds, err := google.FindDefaultCredentials(ctx, "https://www.googleapis.com/auth/cloud-platform")
 	if err != nil {
 		return fmt.Errorf("finding default credentials: %v", err)
 	}


### PR DESCRIPTION
Fixes #101 . The change has been tested.