### PR TITLE
fix creds scope for SAs during refresh

### DIFF
--- a/server.go
+++ b/server.go
@@ -170,7 +170,7 @@ func deletePullSecret(clientset *kubernetes.Clientset, ns corev1.Namespace) erro
 
 // refreshAllPullSecrets deletes and recreates image registry pull secrets for all namespaces
 func refreshAllPullSecrets() error {
-	creds, err := google.FindDefaultCredentials(context.Background())
+	creds, err := google.FindDefaultCredentials(context.Background(), "https://www.googleapis.com/auth/cloud-platform")
 	if err != nil {
 		return fmt.Errorf("finding default credentials: %v", err)
 	}


### PR DESCRIPTION
This PR: https://github.com/GoogleContainerTools/gcp-auth-webhook/pull/169 missed the case when the secrets are refreshed after an hour.